### PR TITLE
Add hub index pages

### DIFF
--- a/_includes/hub_model_tags.html
+++ b/_includes/hub_model_tags.html
@@ -1,0 +1,16 @@
+<div class="dropdown-menu" id="dropdownFilterTags">
+  {% assign all_tags = site.hub | where: "category", include.category | map: "tags" | join: ',' | split: ',' | uniq | sort %}
+
+  <div class="hub-filter-menu">
+    <ul>
+      <li>
+        <a class="hub-filter" data-tag="all" href="{{ site.baseurl }}/hub/{{include.link}}">All</a>
+      </li>
+      {% for tag in all_tags %}
+        <li>
+          <a class="hub-filter" data-tag="{{ tag }}" href="{{ site.baseurl }}/hub/{{include.link}}/{{ tag }}">{{ tag | capitalize }}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>

--- a/_includes/paginated_hub_cards.html
+++ b/_includes/paginated_hub_cards.html
@@ -1,0 +1,21 @@
+<div class="row hub-cards-wrapper cards-left">
+  {% assign hub = paginator.posts %}
+
+  {% for item in hub %}
+    <div class="col-md-6 research-hub-card-wrapper" data-item-count="{{ forloop.index }}" data-tags="{{ item.tags | join: ',' }}">
+      <div class="card hub-card">
+        <a href="{{ site.baseurl }}{{ item.url }}">
+          <div class="card-body">
+            <div class="hub-card-title-container">
+              <h4>{{ item.title }}</h4>
+            </div>
+            <p class="card-summary">{{ item.summary }}</p>
+            <div class="hub-image">
+              <img src="{{ site.baseurl }}/assets/images/{{ item.image }}">
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  {% endfor %}
+</div>

--- a/_includes/pagination_buttons.html
+++ b/_includes/pagination_buttons.html
@@ -1,0 +1,30 @@
+<div class="d-flex justify-content-center">
+  <ul class="pagination">
+    {% if paginator.previous_page %}
+      <li class="page-item">
+        {% if page.title contains 'Blog' %}
+          <a class="page-link" href="{{ site.baseurl }}{{ paginator.previous_page_path }}">Previous</a>
+        {% else %}
+          <a class="page-link" href="{{ site.baseurl }}/{{ paginator.previous_page_path }}">Previous</a>
+        {% endif %}
+      </li>
+    {% else %}
+      <li class="page-item disabled">
+        <a class="page-link">Previous</a>
+      </li>
+    {% endif %}
+
+    {% if paginator.next_page %}
+      {% if page.title contains 'Blog' %}
+        <li class="page-item"><a class="page-link" href="{{ site.baseurl }}{{ paginator.next_page_path }}">Next</a>
+      {% else %}
+        <li class="page-item"><a class="page-link" href="{{ site.baseurl }}/{{ paginator.next_page_path }}">Next</a>
+      {% endif %}
+    </li>
+    {% else %}
+      <li class="page-item disabled">
+        <a class="page-link">Next</a>
+      </li>
+    {% endif %}
+  </ul>
+</div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -70,28 +70,7 @@
           {% endfor %}
         </div>
 
-        <div class="d-flex justify-content-center">
-
-          <ul class="pagination">
-            {% if paginator.previous_page %}
-            <li class="page-item">
-              <a class="page-link" href="{{ site.baseurl }}{{ paginator.previous_page_path }}">Previous</a>
-            </li>
-            {% else %}
-            <li class="page-item disabled">
-              <a class="page-link">Previous</a>
-            </li>
-            {% endif %} {% if paginator.next_page %}
-            <li class="page-item">
-              <a class="page-link" href="{{ site.baseurl }}{{ paginator.next_page_path }}">Next</a>
-            </li>
-            {% else %}
-            <li class="page-item disabled">
-              <a class="page-link">Next</a>
-            </li>
-            {% endif %}
-          </ul>
-        </div>
+        {% include pagination_buttons.html %}
       </div>
     </div>
   </div>

--- a/_layouts/hub_detail.html
+++ b/_layouts/hub_detail.html
@@ -10,7 +10,14 @@
       <div class="container">
         <img src="{{ site.baseurl }}/assets/images/pytorch-hub-arrow.svg"></img>
         <h1>
-          <span class="detail-arrow"><a href="{{ site.baseurl }}/hub"><</a></span> <br>
+          <span class="detail-arrow">
+            {% if page.category == 'researchers' %}
+              <a href="{{ site.baseurl }}/hub/research-models"><</a>
+            {% else %}
+              <a href="{{ site.baseurl }}/hub/developer-models"><</a>
+            {% endif %}
+          </span>
+          <br>
           {{ page.title }}
         </h1>
 

--- a/_layouts/hub_index.html
+++ b/_layouts/hub_index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  {% include head.html %}
+  <body class="{{ page.body-class }} hub-index">
+    {% include header.html %}
+
+    <div class="main-background {{ page.background-class }} hub-index-background"></div>
+
+    <div class="jumbotron jumbotron-fluid">
+      <div class="container">
+        <h1>
+          <span id="hub-header">PyTorch</span> <span id="hub-sub-header"></span>Hub</span> <br>
+          {{ page.title }}
+        </h1>
+
+        <p class="lead">{{ page.summary }}</p>
+      </div>
+    </div>
+
+    <div class="main-content-wrapper">
+      <div class="main-content">
+        <div class="container">
+          <!-- START CONTENT -->
+          <div class="row" id="model-row">
+            <div class="col-md-12 hub-column">
+              <nav class="navbar navbar-expand-lg navbar-light research-menu">
+                <a id="dropdownFilter" data-toggle="dropdown" data-target="#dropdownFilterTags">
+                  Filter <img src="{{ site.baseurl }}/assets/images/filter-arrow.svg">
+                </a>
+
+                {{ content }}
+              </nav>
+
+              <hr>
+
+              {% include paginated_hub_cards.html %}
+            </div>
+          </div>
+
+          {% include pagination_buttons.html %}
+        </div>
+      </div>
+    </div>
+
+    {% include footer.html %}
+  </body>
+</html>

--- a/_sass/hub.scss
+++ b/_sass/hub.scss
@@ -283,6 +283,10 @@
   padding-bottom: rem(75px);
 }
 
+.hub.hub-index .hub-column {
+  padding-bottom: 0;
+}
+
 .hub .how-it-works {
   padding-top: rem(50px);
   padding-bottom: rem(45px);
@@ -391,6 +395,20 @@
   }
 }
 
+.hub .col-md-12.hub-column {
+  .col-md-6 {
+    @media (min-width: 768px) {
+      flex: 0 0 100%;
+      max-width: 100%;
+    }
+
+    @include max-width-desktop {
+      flex: 0 0 100%;
+      max-width: 50%;
+    }
+  }
+}
+
 .hub .featured-image {
   padding-bottom: rem(20px);
 }
@@ -398,4 +416,35 @@
 .hub .coming-soon {
   font-weight: 300;
   font-style: italic;
+}
+
+.hub.hub-index .jumbotron {
+  @include desktop {
+    height: 325px;
+  }
+  h1 {
+    @include desktop {
+      padding-top: rem(55px);
+    }
+    padding-top: 0;
+  }
+  p.lead {
+    padding-top: rem(55px);
+  }
+}
+
+.hub.hub-index .main-content-wrapper {
+  @include desktop {
+    margin-top: 190px + $desktop_header_height;
+  }
+  margin-top: 210px;
+}
+
+.hub .page-link {
+  font-size: rem(20px);
+  letter-spacing: 0;
+  line-height: rem(34px);
+  color: $orange;
+  width: rem(120px);
+  text-align: center;
 }

--- a/hub/developer_models_index.html
+++ b/hub/developer_models_index.html
@@ -1,0 +1,18 @@
+---
+layout: hub_index
+title: Developer Models
+permalink: hub/developer-models
+background-class: hub-background
+body-class: hub
+summary: Get plug & play models to accelerate ML development.
+pagination:
+  title: ':title'
+  enabled: true
+  per_page: 12
+  category: developers
+  sort_reverse: false
+  sort_field: order
+  collection: hub
+---
+
+{% include hub_model_tags.html category="developers" link="developer-models" %}

--- a/hub/hub.html
+++ b/hub/hub.html
@@ -75,7 +75,7 @@ body-class: hub
           <div class="row hub-cards-wrapper cards-left">
             {% assign hub = site.hub | where: "category", "researchers" | sort: "order" %}
 
-            {% for item in hub %}
+            {% for item in hub limit: 3 %}
               <div class="col-md-12 research-hub-card-wrapper" data-item-count="{{ forloop.index }}" data-tags="{{ item.tags | join: ',' }}">
                 <div class="card hub-card">
                   <a href="{{ site.baseurl }}{{ item.url }}">
@@ -97,8 +97,7 @@ body-class: hub
 
           <div class="row">
             <div class="col-md-12 buttons-container">
-              <button class="all-models-button" id="research-models">All Research Models ({{ hub | size}})</button>
-              <button class="all-models-button" id="research-models-hide">Fewer Research Models</button>
+              <a class="all-models-button" id="research-models" href="{{ site.baseurl }}/hub/research-models">All Research Models ({{ hub | size}})</a>
             </div>
           </div>
         </div>
@@ -178,8 +177,7 @@ body-class: hub
 
           <div class="row">
             <div class="col-md-12">
-              <button class="all-models-button" id="development-models">All Development Models ({{ hub | size}})</button>
-              <button class="all-models-button" id="development-models-hide">Fewer Development Models</button>
+              <a class="all-models-button" id="development-models" href="{{ site.baseurl }}/hub/developer-models">All Developer Models ({{ hub | size}})</a>
             </div>
           </div>
           -->
@@ -222,4 +220,3 @@ body-class: hub
 </div>
 
 <script src="{{ site.baseurl }}/assets/hub-filter.js"></script>
-<script src="{{ site.baseurl }}/assets/hub-buttons.js"></script>

--- a/hub/research_models_index.html
+++ b/hub/research_models_index.html
@@ -1,0 +1,18 @@
+---
+layout: hub_index
+title: Research Models
+permalink: hub/research-models
+background-class: hub-background
+body-class: hub
+summary: Explore and extend models from the latest cutting edge research.
+pagination:
+  title: ':title'
+  enabled: true
+  per_page: 12
+  category: researchers
+  sort_reverse: false
+  sort_field: order
+  collection: hub
+---
+
+{% include hub_model_tags.html category="researchers" link="research-models" %}

--- a/hub/research_tags/audio.html
+++ b/hub/research_tags/audio.html
@@ -1,0 +1,19 @@
+---
+layout: hub_index
+title: Research Models
+permalink: hub/research-models/audio
+background-class: hub-background
+body-class: hub
+summary: Explore and extend models from the latest cutting edge research.
+pagination:
+  title: ':title'
+  enabled: true
+  per_page: 12
+  category: researchers
+  tag: audio
+  sort_reverse: false
+  sort_field: order
+  collection: hub
+---
+
+{% include hub_model_tags.html category="researchers" link="research-models" %}

--- a/hub/research_tags/generative.html
+++ b/hub/research_tags/generative.html
@@ -1,0 +1,19 @@
+---
+layout: hub_index
+title: Research Models
+permalink: hub/research-models/generative
+background-class: hub-background
+body-class: hub
+summary: Explore and extend models from the latest cutting edge research.
+pagination:
+  title: ':title'
+  enabled: true
+  per_page: 12
+  category: researchers
+  tag: generative
+  sort_reverse: false
+  sort_field: order
+  collection: hub
+---
+
+{% include hub_model_tags.html category="researchers" link="research-models" %}

--- a/hub/research_tags/nlp.html
+++ b/hub/research_tags/nlp.html
@@ -1,0 +1,19 @@
+---
+layout: hub_index
+title: Research Models
+permalink: hub/research-models/nlp
+background-class: hub-background
+body-class: hub
+summary: Explore and extend models from the latest cutting edge research.
+pagination:
+  title: ':title'
+  enabled: true
+  per_page: 12
+  category: researchers
+  tag: nlp
+  sort_reverse: false
+  sort_field: order
+  collection: hub
+---
+
+{% include hub_model_tags.html category="researchers" link="research-models" %}

--- a/hub/research_tags/vision.html
+++ b/hub/research_tags/vision.html
@@ -1,0 +1,19 @@
+---
+layout: hub_index
+title: Research Models
+permalink: hub/research-models/vision
+background-class: hub-background
+body-class: hub
+summary: Explore and extend models from the latest cutting edge research.
+pagination:
+  title: ':title'
+  enabled: true
+  per_page: 12
+  category: researchers
+  tag: vision
+  sort_reverse: false
+  sort_field: order
+  collection: hub
+---
+
+{% include hub_model_tags.html category="researchers" link="research-models" %}


### PR DESCRIPTION
This PR adds index pages for the research and developer model cards. (The developer model cards aren't live yet.) Each index page features pagination. When you select a filter tag on the index page, the tag should carry over to each page. (The vision tag is an example.) Clicking the 'All Research Models' button will take you to the index page: https://5d2cbb91e661ea422b2e8e1c--shiftlab-pytorch-github-io.netlify.com/hub/.