### PR TITLE
Sort Ecosystem cards alphabetically

### DIFF
--- a/ecosystem/ecosystem.html
+++ b/ecosystem/ecosystem.html
@@ -63,7 +63,7 @@ body-class: ecosystem
       <!-- START CONTENT -->
 
       <div class="row ecosystem-cards-wrapper">
-        {% assign ecosystem = site.ecosystem  | sort: 'order' %}
+        {% assign ecosystem = site.ecosystem  | sort_natural: "title" %}
 
         {% for item in ecosystem %}
           <div class="col-md-6 ecosystem-card-wrapper" data-categories="{{ item.category | join: "," }}">


### PR DESCRIPTION
Changed Ecosystem Tools cards to sort by title alphabetically. 
`sort_natural` is needed for case-insensitivity.