### PR TITLE
GitHub Star Icon

### DIFF
--- a/_includes/compact_hub_cards.html
+++ b/_includes/compact_hub_cards.html
@@ -8,7 +8,15 @@
         <a href="{{ site.baseurl }}{{ item.url }}">
           <div class="compact-card-body">
             <div class="compact-card-container">
-              <h4 class="compact-item-title col-6">{{ item.title }}</h4>
+              <div class="compact-hub-card-title-container">
+                <h4 class="compact-item-title">{{ item.title }}</h4>
+                <div class="detail-stars-container col-2">
+                  <div class="github-stars-image">
+                    <img src="/assets/images/github-star.svg">
+                  </div>
+                  <div class="github-stars-count"></div>
+                </div>
+              </div>
               <p class="compact-card-summary card-summary col-6">{{ item.summary }}</p>
             </div>
           </div>

--- a/_includes/hub_cards.html
+++ b/_includes/hub_cards.html
@@ -9,6 +9,12 @@
             <div class="card-body">
               <div class="hub-card-title-container">
                 <h4 class="card-title">{{ item.title }}</h4>
+                <div class="main-stars-container">
+                  <div class="github-stars-image">
+                    <img src="/assets/images/github-star.svg">
+                  </div>
+                  <div class="github-stars-count"></div>
+                </div>
               </div>
               <p class="card-summary">{{ item.summary }}</p>
               <div class="hub-image">

--- a/_sass/compact.scss
+++ b/_sass/compact.scss
@@ -26,6 +26,10 @@
       color: $orange
     }
   }
+  .compact-hub-card-title-container {
+    width: 75%;
+    display: flex;
+  }
 }
 
 .compact-model-card {
@@ -42,6 +46,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  top: 5px;
 }
 
 .compact-hub-divider {
@@ -69,7 +74,7 @@
 .compact-hub-icon {
   margin-left: 0.5rem;
   &:hover {
-    cursor: pointer; 
+    cursor: pointer;
   }
 }
 

--- a/_sass/hub.scss
+++ b/_sass/hub.scss
@@ -230,6 +230,10 @@
   font-size: rem(20px);
 }
 
+.hub .main-stars-container {
+  display: flex;
+}
+
 .hub .detail-stars-container {
   display: inline-flex;
   .github-stars-image {
@@ -254,6 +258,9 @@
         width: rem(96px);
         text-align: center;
         margin-top: rem(4px);
+    }
+    .card-title {
+      padding-left: 0;
     }
   }
 }

--- a/hub/hub.html
+++ b/hub/hub.html
@@ -67,6 +67,12 @@ body-class: hub
                       <div class="card-body">
                         <div class="hub-card-title-container">
                           <h4>{{ item.title }}</h4>
+                          <div class="main-stars-container">
+                            <div class="github-stars-image">
+                              <img src="/assets/images/github-star.svg">
+                            </div>
+                            <div class="github-stars-count"></div>
+                          </div>
                         </div>
                         <p class="card-summary">{{ item.summary }}</p>
                         <div class="hub-image">


### PR DESCRIPTION
This PR adds GitHub star icon to hub cards

Preview: https://5e8c84fcd0145b018028de46--shiftlab-pytorch-github-io.netlify.com/hub/research-models