### PR TITLE
Sort by GitHub stars count

### DIFF
--- a/assets/filter-hub-tags.js
+++ b/assets/filter-hub-tags.js
@@ -4,7 +4,7 @@ var displayCount = Number(filterScript.attr("display-count"));
 var pagination = filterScript.attr("pagination");
 
 var options = {
-  valueNames: [{ data: ["tags"] }],
+  valueNames: ["github-stars-count", { data: ["tags"] }],
   page: displayCount
 };
 
@@ -66,4 +66,12 @@ $(".filter-btn").on("click", function() {
   }
 
   updateList();
+});
+
+$("#sortLowLeft").on("click", function() {
+  hubList.sort("github-stars-count", { order: "asc" });
+});
+
+$("#sortHighLeft").on("click", function() {
+  hubList.sort("github-stars-count", { order: "desc" });
 });


### PR DESCRIPTION
Add ability to sort Hub cards by GitHub stars count

Preview with mock star counts: https://5e9a1f277824fa21687520cf--shiftlab-pytorch-github-io.netlify.app/hub/