### PR TITLE
Replace star icon with Github logo

### DIFF
--- a/_includes/hub_cards.html
+++ b/_includes/hub_cards.html
@@ -11,10 +11,10 @@
                 <ul class="star-list">
                   <li class="card-title">{{ item.title }}</li>
                   <div class="icon-count-container">
-                    <li class="github-stars-image">
-                      <img src="/assets/images/github-star.svg">
+                    <li>
+                      <li><img class="github-logo" src="/assets/images/logo-github.svg"></li>
                     </li>
-                    <li class="github-stars-count"></li>
+                    <li class="github-stars-count">23</li>
                   </div>
                 </ul>
               </div>

--- a/_sass/hub.scss
+++ b/_sass/hub.scss
@@ -212,32 +212,26 @@
   }
 }
 
-.hub .github-stars-image {
-  height: 8px;
-  width: 8px;
-  margin-left: rem(15px);
-  position: relative;
-  bottom: rem(6px);
-  @include desktop {
-    height: 9px;
-    width: 9px;
-    bottom: rem(4px);
-  }
-}
-
 .hub .github-stars-count {
   color: $mid_gray;
   position: relative;
-  bottom: rem(4px);
-  font-size: rem(16px);
+  top: rem(4px);
+  font-size: 14px;
   @include desktop {
+    top: rem(3px);
     font-size: initial;
   }
 }
 
+.hub .github-logo {
+  height: 15px;
+  width: 13px;
+}
+
 .hub .icon-count-container {
   display: inline-block;
-  vertical-align: middle ;
+  vertical-align: text-bottom;
+  margin-left: rem(8px);
 }
 
 .hub .detail-count {

--- a/hub/hub.html
+++ b/hub/hub.html
@@ -53,8 +53,8 @@ body-class: hub
                           <ul class="star-list">
                             <li class="card-title">{{ item.title }}</li>
                             <div class="icon-count-container">
-                              <li class="github-stars-image">
-                                <img src="/assets/images/github-star.svg">
+                              <li>
+                                <li><img class="github-logo" src="/assets/images/logo-github.svg"></li>
                               </li>
                               <li class="github-stars-count"></li>
                             </div>


### PR DESCRIPTION
This PR replaces Github star icon with Github logo