### PR TITLE
Update quick start module language

### DIFF
--- a/_includes/quick_start_module.html
+++ b/_includes/quick_start_module.html
@@ -3,8 +3,7 @@
     <div class="row">
       <div class="col-md-8 start-locally-col">
 
-        <h3>Quick Start
-          <br />Locally</h3>
+        <h3>Install PyTorch</h3>
 
         {% include quick_start_local.html %}
 


### PR DESCRIPTION
This PR only updates the language on the quick start locally module. On the Get Started page the text about the install module still reads Start Locally.