### PR TITLE
Truncate hub card titles and summaries

### DIFF
--- a/_includes/hub_cards.html
+++ b/_includes/hub_cards.html
@@ -9,7 +9,7 @@
             <div class="card-body">
               <div class="hub-card-title-container">
                 <ul class="star-list">
-                  <li class="card-title">{{ item.title }}</li>
+                  <li class="card-title">{{ item.title | truncate: 25 }}</li>
                   <div class="icon-count-container">
                     <li>
                       <li><img class="github-logo" src="/assets/images/logo-github.svg"></li>
@@ -19,7 +19,7 @@
                   </div>
                 </ul>
               </div>
-              <p class="card-summary">{{ item.summary }}</p>
+              <p class="card-summary">{{ item.summary | truncate: 150 }}</p>
               <div class="hub-image">
                 <img src="{{ site.baseurl }}/assets/images/{{ item.image }}">
               </div>

--- a/hub/hub.html
+++ b/hub/hub.html
@@ -51,7 +51,7 @@ body-class: hub
                       <div class="card-body">
                         <div class="hub-card-title-container">
                           <ul class="star-list">
-                            <li class="card-title">{{ item.title }}</li>
+                            <li class="card-title">{{ item.title | truncate: 25 }}</li>
                             <div class="icon-count-container">
                               <li>
                                 <li><img class="github-logo" src="/assets/images/logo-github.svg"></li>
@@ -61,7 +61,7 @@ body-class: hub
                             </div>
                           </ul>
                         </div>
-                        <p class="card-summary">{{ item.summary }}</p>
+                        <p class="card-summary">{{ item.summary | truncate: 150 }}</p>
                         <div class="hub-image">
                           <img src="{{ site.baseurl }}/assets/images/{{ item.image }}">
                         </div>


### PR DESCRIPTION
This PR truncates the hub card titles and summaries so that this issue doesn't occur: 

<img width="721" alt="hub cards" src="https://user-images.githubusercontent.com/16585245/91894467-ba50db00-ec63-11ea-81a9-1809715cc580.png">
