### PR TITLE
Create "Demo Model Output" button

### DIFF
--- a/_layouts/hub_detail.html
+++ b/_layouts/hub_detail.html
@@ -20,14 +20,19 @@
         </h1>
 
         <div class="row">
-          <div class="col-md-6">
+          <div class="col-md-4">
             <p class="detail-lead">By {{ page.author }} </p>
           </div>
 
-          <div class="col-md-6">
+          <div class="col-md-8">
             <p class="detail-lead lead-summary">{{ page.summary }}</p>
-            <a href="{{ page.github-link }}"><button class="btn btn-lg with-right-white-arrow detail-github-link">View on Github</button></a>
-            <a href="https://colab.research.google.com/github/pytorch/pytorch.github.io/blob/master/{{ page.path | replace: "_hub", "assets/hub" | replace: ".md", ".ipynb" }}"><button class="btn btn-lg with-right-white-arrow detail-colab-link">Open on Google Colab</button></a>
+            <div class="detail-button-contain">
+              <a href="{{ page.github-link }}"><button class="btn btn-lg with-right-white-arrow detail-github-link">View on Github</button></a>
+              <a href="https://colab.research.google.com/github/pytorch/pytorch.github.io/blob/master/{{ page.path | replace: "_hub", "assets/hub" | replace: ".md", ".ipynb" }}"><button class="btn btn-lg with-right-white-arrow detail-colab-link">Open on Google Colab</button></a>
+              {% if page.demo-model == true %}
+                <a href="{{ page.demo-model-link }}"><button class="btn btn-lg with-right-white-arrow detail-web-demo-link">Run Web Demo Notebook</button></a>
+              {% endif %}
+            </div>
           </div>
         </div>
       </div>

--- a/_layouts/hub_detail.html
+++ b/_layouts/hub_detail.html
@@ -26,7 +26,7 @@
 
           <div class="col-md-8">
             <p class="detail-lead lead-summary">{{ page.summary }}</p>
-            <div class="detail-button-contain">
+            <div class="detail-button-container">
               <a href="{{ page.github-link }}"><button class="btn btn-lg with-right-white-arrow detail-github-link">View on Github</button></a>
               <a href="https://colab.research.google.com/github/pytorch/pytorch.github.io/blob/master/{{ page.path | replace: "_hub", "assets/hub" | replace: ".md", ".ipynb" }}"><button class="btn btn-lg with-right-white-arrow detail-colab-link">Open on Google Colab</button></a>
               {% if page.demo-model == true %}

--- a/_sass/hub.scss
+++ b/_sass/hub.scss
@@ -62,8 +62,19 @@
   color: $black;
 }
 
+.hub .detail-web-demo-link {
+  background: #4a9fb5;
+  color: $white;
+}
+
 .hub {
-  .detail-colab-link, .detail-github-link {
+  .detail-colab-link, .detail-github-link, .detail-web-demo-link {
+    margin-top: 1rem;
+  }
+}
+
+.hub {
+  .detail-button-contain {
     margin-top: rem(45px);
     @include small-desktop {
       margin-top: rem(20px);

--- a/_sass/hub.scss
+++ b/_sass/hub.scss
@@ -74,7 +74,7 @@
 }
 
 .hub {
-  .detail-button-contain {
+  .detail-button-container {
     margin-top: rem(45px);
     @include small-desktop {
       margin-top: rem(20px);


### PR DESCRIPTION
This PR adds "Run Web Demo Notebook" button to models where `demo-model` is set to true. 

Preview model with button: https://608817031caae34f7df2e1ec--shiftlab-pytorch-github-io.netlify.app//hub/intelisl_midas_v2/

There will need to be a separate PR opened in the hub repo with the new front-matter added to the models where this button should show up. 