### PR TITLE
Change min width for full nav variable

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -33,7 +33,7 @@ $site_horizontal_padding: 30px;
 }
 
 @mixin full-nav-menu-desktop {
-  @media screen and (min-width: 1100px) { @content; }
+  @media screen and (min-width: 1200px) { @content; }
 }
 
 @mixin max-width-desktop {


### PR DESCRIPTION
This PR fixes the issue of the PyTorch home button and "Get Started" nav link overlapping at certain widths.

Screenshot of issue: 
<img width="1129" alt="Screen Shot 2021-05-10 at 3 59 31 PM" src="https://user-images.githubusercontent.com/31549535/117717482-dcaed700-b1a8-11eb-8671-84985a953609.png">

Preview with fix: https://shiftlab-pytorch-github-io.netlify.app/
